### PR TITLE
add posh-dotnet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ It includes a command-line shell and an associated scripting language.
 - [pslinq](https://github.com/manojlds/pslinq) - LINQ (LINQ2Objects) for Powershell.
 - [posh-with](https://github.com/JanJoris/posh-with) - Command prefixing for continuous workflow using a single tool.
 - [poco](https://gist.github.com/yumura/8df37c22ae1b7942dec7) - [peco](https://github.com/peco/peco) implementation. Interactive filtering tool.
+- [posh-dotnet](https://github.com/bergmeister/posh-dotnet) - `PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli).
 
 ## Communities
 


### PR DESCRIPTION
 [posh-dotnet](https://github.com/bergmeister/posh-dotnet) 
`PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli).

This module enhances the tab completion of the dotnet cli 2.0 (which is disabled by default) and also provides support for the dotnet cli 1.0 (which had not tab completion at all)