### PR TITLE
Add PSDirTag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ It includes a command-line shell and an associated scripting language.
 - [pslinq](https://github.com/manojlds/pslinq) - LINQ (LINQ2Objects) for Powershell.
 - [posh-with](https://github.com/JanJoris/posh-with) - Command prefixing for continuous workflow using a single tool.
 - [poco](https://gist.github.com/yumura/8df37c22ae1b7942dec7) - [peco](https://github.com/peco/peco) implementation. Interactive filtering tool.
+- [PSDirTag](https://github.com/wtjones/PSDirTag) - DirTags are relative paths that appear as variables in the Powershell prompt that update as you navigate. Saves keystrokes when navigating folder structures.
 
 ## Communities
 


### PR DESCRIPTION
This is a module that helps with navigating repos or any folder structure. I use it on a regular basis to switch between common relative paths, even between separate branch folders (`somebranch/LotsOfNesting.../tests -> otherbranch/LotsOfNesting.../tests` for example).

https://github.com/wtjones/PSDirTag (also available on PS gallery)