### PR TITLE
Added AWSCBManifestPS to Build Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ It includes a command-line shell and an associated scripting language.
 * [PSDeploy](https://github.com/RamblingCookieMonster/PSDeploy) - Module built for the purpose of simplifying multiple types of deployments.
 * [BuildHelpers](https://github.com/RamblingCookieMonster/BuildHelpers) - Variety of helper functions for CI/CD scenarios.
 * [YDeliver](https://github.com/manojlds/YDeliver) - Build and deployment framework aimed at .NET projects.
+* [AWSCBManifestPS](https://github.com/techthoughts2/AWSCBManifestPS) - Scaffolds a new PowerShell module project intended for CI/CD workflow using AWS CodeBuild.
 
 ## Code and Package Repositories
 


### PR DESCRIPTION
### Link to the package

[AWSCBManifestPS](https://github.com/techthoughts2/AWSCBManifestPS)

### Why it should be included

This is a custom Plaster manifest template that can be invoked using the Plaster module. It can rapidly generate a PowerShell module project for use with AWS CodeBuild.
Rapidly scaffold module layout, required build files, and CloudFormation templates so that you can focus on building a great PowerShell module instead of the build process.