### PR TITLE
Added scoop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,7 @@ It includes a command-line shell and an associated scripting language.
 * [PsGet](http://psget.net/) - Set of commands to install modules from central directory, local file or from the web.
 * [Chocolatey](https://chocolatey.org/) - The package manager for Windows. The sane way to manage software on Windows.
 * [GitLab](https://github.com/akamac/GitLabProvider) - Use a GitLab server as Package Provider.
+* [Scoop](https://scoop.sh) - A command line installer for Windows.
 
 ## Parallel Processing
 


### PR DESCRIPTION
URL - https://scoop.sh/

Scoop installs packages in the user scope and keeps the paths clean. It's an alternative to Chocolatey and has a focus on open source. Additional installations can be added by buckets. 

