### PR TITLE
(Package Managers): Remove PsGet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,6 @@ It includes a command-line shell and an associated scripting language.
 ## Package Managers
 
 * [PowerShellGet](https://github.com/powershell/powershellget) - PowerShellGet is the Package Manager for PowerShell. Packages are available on [PowerShellGallery](https://www.PowerShellGallery.com).
-* [PsGet](http://psget.net/) - Set of commands to install modules from central directory, local file or from the web.
 * [Chocolatey](https://chocolatey.org/) - The package manager for Windows. The sane way to manage software on Windows.
 * [GitLab](https://github.com/akamac/GitLabProvider) - Use a GitLab server as Package Provider.
 


### PR DESCRIPTION
The site (https://psget.net is down. The module does not seem to be actively maintained. The readme of the project suggests that PsGet is installed using the website that is currently down.