### PR TITLE
(Code and Package Repositories): Remove TechNet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,6 @@ It includes a command-line shell and an associated scripting language.
 
 * [GitHub](https://github.com/search?l=powershell&q=stars%3A%3E1&s=stars&type=Repositories) - Looking for an Open Source PowerShell project? It's probably here.
 * [PowerShell Gallery](https://www.powershellgallery.com/) - Official PowerShell package repository, used by PowerShellGet.
-* [TechNet Gallery](https://gallery.technet.microsoft.com/) - Wide variety of PowerShell code from snippets to modules.
 
 ## Commandline Productivity
 


### PR DESCRIPTION
TechNet Gallery is retiring in June 2020.

https://docs.microsoft.com/en-us/teamblog/technet-gallery-retirement