### PR TITLE
Change QA to run everyday

### DIFF
--- a/.github/workflows/QualityAssurance.yml
+++ b/.github/workflows/QualityAssurance.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
   schedule:
   # * is a special character in YAML so you have to quote this string
-  - cron:  '0 0 * * 0'
+  - cron:  '0 0 * * *'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This PR is just a simple suggestion to have the QA executed everyday.

As it is now, if a QA runs Monday, the QA badge will say failing until it is ran again at Sunday. Not sure if it will be too noisy?