### PR TITLE
Fix dead link to PowerScripting podcast

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ It includes a command-line shell and an associated scripting language.
 
 ## Podcasts
 
-* [PowerScripting](https://powershell.org/podcast/) - Weekly show run by Jon Walz and Hal Rottenberg.
+* [PowerScripting](https://powershell.org/category/podcast/) - Weekly show run by Jon Walz and Hal Rottenberg.
 * [The PowerShell News Podcast](https://powershellnews.podbean.com/) - This podcast is the latest news on PowerShell.
 
 ## Security


### PR DESCRIPTION
The QA was failing the podcast link being updated to https://powershell.org/category/podcast/