### PR TITLE
Add m2cgen for transpiling ML models into PowerShell code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -272,6 +272,7 @@ It includes a command-line shell and an associated scripting language.
 ## Misc
 
 * [DbgShell](https://github.com/Microsoft/DbgShell) - A PowerShell front-end for the Windows debugger engine.
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native PowerShell code with zero dependencies.
 * [poke](https://github.com/oising/poke) - Crazy cool reflection module for PowerShell.
   Explore and invoke private APIs like nobody is watching.
   Useful for security research, testing and quick hacks.


### PR DESCRIPTION
`m2cgen` is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of PowerShell programming language. Examples of generated PS code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/powershell).